### PR TITLE
excluded_subgroups + minor tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 coverage
-
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM ruby:2.7-alpine
 
 ENV DRY_RUN=false
 ENV CI_API_V4_URL=https://gitlab.com/api/v4
-ENV GGM_CONFIG_FILE=.ggm.yaml
 ENV PATH="/usr/src/app/bin:${PATH}"
 
 RUN apk add --no-cache bash

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ NOTE: See [examples/hello-world](examples/hello-world) for a complete example
 ```
 groups:
   - name: Example Group
-    include_subgroups: false
+    excluded_subgroups:
+      - 'SubGroup 1'
     archived: false
     files: 
       - path: .gitlab/merge_request_templates/Default.md

--- a/bin/ggm
+++ b/bin/ggm
@@ -10,7 +10,7 @@ require_relative '../lib/gitlab_group_manager'
 #   - GGM_CONFIG_FILE if your config is not in the current directory (default: ./.ggml.yaml)
 #   - DRY_RUN if you just want to see what would happen, without making any changes (valid values: true/t/yes)
 def main
-  config = GGM::ConfigParser.new(config_file_path: GGM::Env['GGM_CONFIG_FILE' || '.ggm.yaml'])
+  config = GGM::ConfigParser.new(config_file_path: GGM::Env['GGM_CONFIG_FILE'] || '.ggm.yaml')
   config.apply
 end
 

--- a/bin/ggm
+++ b/bin/ggm
@@ -10,8 +10,15 @@ require_relative '../lib/gitlab_group_manager'
 #   - GGM_CONFIG_FILE if your config is not in the current directory (default: ./.ggml.yaml)
 #   - DRY_RUN if you just want to see what would happen, without making any changes (valid values: true/t/yes)
 def main
-  config = GGM::ConfigParser.new(config_file_path: GGM::Env['GGM_CONFIG_FILE'] || '.ggm.yaml')
+  config = GGM::ConfigParser.new(config_file_path: GGM::Env['GGM_CONFIG_FILE'] || default_config_path)
   config.apply
+end
+
+def default_config_path
+  return '.ggm.yaml' if File.exist?('.ggm.yaml')
+  return '.ggm.yml' if File.exist?('.ggm.yml')
+
+  raise 'No .ggm.y[a]ml config file found'
 end
 
 main

--- a/examples/hello-world/.ggm.yaml
+++ b/examples/hello-world/.ggm.yaml
@@ -1,7 +1,13 @@
 groups:
+  # Name of the group to operate on, must match exactly
   - name: Example Group
-    include_subgroups: false
+    # Each entry in the excluded_subgroups array is a regex, any subgroup name that matches is excluded
+    excluded_subgroups: 
+      # Exclude all subgroups 
+      - '.*'
+    # exclude archived projects
     archived: false
     files: 
-      - path: hello.md
+      - path: shared-files/hello.md
+        # Add the following string to the end of any commits related to this file
         commit_suffix: ' [skip ci]'

--- a/examples/hello-world/hello.md
+++ b/examples/hello-world/hello.md
@@ -1,1 +1,0 @@
-# This is a test

--- a/examples/hello-world/shared-files/hello.md
+++ b/examples/hello-world/shared-files/hello.md
@@ -1,0 +1,1 @@
+Hello World!

--- a/integration-tests/integration_spec.rb
+++ b/integration-tests/integration_spec.rb
@@ -120,7 +120,6 @@ describe 'Integration Tests' do
     end
   end
 
-
   context 'with all subgroups excluded' do
     let(:basic_config) do
       { 'groups' => [

--- a/integration-tests/integration_spec.rb
+++ b/integration-tests/integration_spec.rb
@@ -1,29 +1,41 @@
 # frozen_string_literal: true
 
+require_relative 'spec_helper'
+
 require 'gitlab'
 require 'yaml'
 
 # Disable some rspec best practices, as our integration tests need state to persist across each test
-# rubocop:disable RSpec/BeforeAfterAll, RSpec/ExampleLength, RSpec/MultipleExpectations, RSpec/InstanceVariable, RSpec/DescribeClass
+# rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations, RSpec/InstanceVariable, RSpec/DescribeClass
 describe 'Integration Tests' do
-  before(:all) do
+  before do
     Gitlab.private_token = ENV['GITLAB_TOKEN']
     @group = Gitlab.create_group('Integration Test Group', 'integration-test-group',
                                  { parent_id: ENV['INTEGRATION_TEST_PARENT_GROUP_ID'] })
     @projects = 3.times.map do |i|
       Gitlab.create_project("project#{i}", { namespace_id: @group.id })
     end
+
+    @sub_groups_and_projects = 3.times.map do |i|
+      group = Gitlab.create_group("Integration Test SubGroup #{i}",
+                                  "integration-test-subgroup-#{i}",
+                                  { parent_id: @group.id })
+      projects = 2.times.map do |j|
+        Gitlab.create_project("sub-group-#{i}-project#{j}", { namespace_id: group.id })
+      end
+      { group: group, projects: projects }
+    end
   end
 
-  after(:all) do
+  after do
     Gitlab.delete_group(@group.id)
+    sleep 5
   end
 
   context 'with basic config for a single file' do
     let(:basic_config) do
       { 'groups' => [
         { 'name' => @group.name,
-          'include_subgroups' => false,
           'archived' => false,
           'files' => [
             { 'path' => 'hello.md' }
@@ -38,16 +50,114 @@ describe 'Integration Tests' do
       File.open('/tmp/.ggm.yaml', 'w') { |file| file.write(basic_config) }
     end
 
-    it 'writes the expected file to every project' do
+    it 'writes the expected file to expected projects' do
       @projects.each do |project|
         expect { Gitlab.get_file(project.id, 'hello.md', 'master') }.to raise_error(Gitlab::Error::NotFound)
       end
 
-      Dir.chdir('/tmp') { `'ggm'` }
+      run_ggm
 
+      # projects in main groups are included
       @projects.each do |project|
         get_file_response = Gitlab.get_file(project.id, 'hello.md', 'master')
         expect(get_file_response.content_sha256).to eq(Digest::SHA256.hexdigest(file_contents))
+      end
+
+      # projects in sub groups are included too
+      @sub_groups_and_projects.each do |tuple|
+        tuple[:projects].each do |project|
+          get_file_response = Gitlab.get_file(project.id, 'hello.md', 'master')
+          expect(get_file_response.content_sha256).to eq(Digest::SHA256.hexdigest(file_contents))
+        end
+      end
+    end
+  end
+
+  context 'with certain subgroups excluded' do
+    let(:basic_config) do
+      { 'groups' => [
+        { 'name' => @group.name,
+          'excluded_subgroups' => ['Integration Test SubGroup 2'],
+          'archived' => false,
+          'files' => [
+            { 'path' => 'hello.md' }
+          ] }
+      ] }.to_yaml
+    end
+
+    let(:file_contents) { "Hello World\n" }
+
+    before do
+      File.open('/tmp/hello.md', 'w') { |file| file.write(file_contents) }
+      File.open('/tmp/.ggm.yaml', 'w') { |file| file.write(basic_config) }
+    end
+
+    it 'writes the expected file to expected projects' do
+      @projects.each do |project|
+        expect { Gitlab.get_file(project.id, 'hello.md', 'master') }.to raise_error(Gitlab::Error::NotFound)
+      end
+
+      run_ggm
+
+      # projects in main groups are included
+      @projects.each do |project|
+        get_file_response = Gitlab.get_file(project.id, 'hello.md', 'master')
+        expect(get_file_response.content_sha256).to eq(Digest::SHA256.hexdigest(file_contents))
+      end
+
+      # projects in subgroups 0 & 1 are also included
+      @sub_groups_and_projects.first(2).each do |tuple|
+        tuple[:projects].each do |project|
+          get_file_response = Gitlab.get_file(project.id, 'hello.md', 'master')
+          expect(get_file_response.content_sha256).to eq(Digest::SHA256.hexdigest(file_contents))
+        end
+      end
+
+      # projects in subgroup 2 are not included
+      @sub_groups_and_projects.last[:projects].each do |project|
+        expect { Gitlab.get_file(project.id, 'hello.md', 'master') }.to raise_error(Gitlab::Error::NotFound)
+      end
+    end
+  end
+
+
+  context 'with all subgroups excluded' do
+    let(:basic_config) do
+      { 'groups' => [
+        { 'name' => @group.name,
+          'excluded_subgroups' => ['.*'],
+          'archived' => false,
+          'files' => [
+            { 'path' => 'hello.md' }
+          ] }
+      ] }.to_yaml
+    end
+
+    let(:file_contents) { "Hello World\n" }
+
+    before do
+      File.open('/tmp/hello.md', 'w') { |file| file.write(file_contents) }
+      File.open('/tmp/.ggm.yaml', 'w') { |file| file.write(basic_config) }
+    end
+
+    it 'writes the expected file to expected projects' do
+      @projects.each do |project|
+        expect { Gitlab.get_file(project.id, 'hello.md', 'master') }.to raise_error(Gitlab::Error::NotFound)
+      end
+
+      run_ggm
+
+      # projects in main groups are included
+      @projects.each do |project|
+        get_file_response = Gitlab.get_file(project.id, 'hello.md', 'master')
+        expect(get_file_response.content_sha256).to eq(Digest::SHA256.hexdigest(file_contents))
+      end
+
+      # projects in subgroups are excluded
+      @sub_groups_and_projects.each do |tuple|
+        tuple[:projects].each do |project|
+          expect { Gitlab.get_file(project.id, 'hello.md', 'master') }.to raise_error(Gitlab::Error::NotFound)
+        end
       end
     end
   end
@@ -56,7 +166,6 @@ describe 'Integration Tests' do
     let(:basic_config) do
       { 'groups' => [
         { 'name' => @group.name,
-          'include_subgroups' => false,
           'archived' => false,
           'files' => [
             { 'path' => 'one.md', 'commit_suffix' => ' [skip ci]' },
@@ -73,8 +182,8 @@ describe 'Integration Tests' do
       File.open('/tmp/.ggm.yaml', 'w') { |file| file.write(basic_config) }
     end
 
-    it 'writes the expected file to every project' do
-      Dir.chdir('/tmp') { `'ggm'` }
+    it 'writes the expected files to the expected project with the expected commit message' do
+      run_ggm
 
       @projects.each do |project|
         commits = Gitlab.commits(project.id, { ref: 'master' }).auto_paginate
@@ -85,4 +194,4 @@ describe 'Integration Tests' do
     end
   end
 end
-# rubocop:enable RSpec/BeforeAfterAll, RSpec/ExampleLength, RSpec/MultipleExpectations, RSpec/InstanceVariable, RSpec/DescribeClass
+# rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations, RSpec/InstanceVariable, RSpec/DescribeClass

--- a/integration-tests/spec_helper.rb
+++ b/integration-tests/spec_helper.rb
@@ -11,3 +11,7 @@ RSpec.configure do |config|
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
 end
+
+def run_ggm
+  Dir.chdir('/tmp') { puts `'ggm'` }
+end

--- a/lib/ggm/config_parser.rb
+++ b/lib/ggm/config_parser.rb
@@ -14,6 +14,8 @@ module GGM
     def initialize(config_file_path: '.ggm.yaml')
       @config = YAML.load_file(config_file_path)
       @project_set_configs = build_project_config_tuple
+    rescue StandardError => e
+      raise GGM::ConfigError, e
     end
 
     def apply

--- a/lib/gitlab_group_manager.rb
+++ b/lib/gitlab_group_manager.rb
@@ -25,9 +25,13 @@ module GGM
     end
 
     def initialize(name)
-      @value = ENV[name].to_s.downcase
-      @value = true if TRUTHY_VALUES.include?(@value.to_s)
-      @value = false if FALSEY_VALUES.include?(@value.to_s)
+      if ENV[name].nil?
+        @value = nil
+        return
+      end
+      @value = ENV[name].to_s
+      @value = true if TRUTHY_VALUES.include?(@value.to_s.downcase)
+      @value = false if FALSEY_VALUES.include?(@value.to_s.downcase)
     end
   end
 end

--- a/spec/fixtures/config/.ggm.yaml
+++ b/spec/fixtures/config/.ggm.yaml
@@ -1,6 +1,5 @@
 groups:
   - name: Test Group
-    include_subgroups: false
     archived: false
     files: 
       - path: spec/fixtures/test.md

--- a/spec/ggm/config_parser_spec.rb
+++ b/spec/ggm/config_parser_spec.rb
@@ -5,6 +5,7 @@ describe GGM::ConfigParser do
     with_mock_gitlab_client
     with_gitlab_groups_response_success
     with_gitlab_group_projects_response_success
+    with_gitlab_group_subgroups_response_success
   end
 
   describe '#new' do
@@ -16,7 +17,6 @@ describe GGM::ConfigParser do
           'groups' =>
             [{ 'name' => 'Test Group',
                'archived' => false,
-               'include_subgroups' => false,
                'files' => [{ 'path' => 'spec/fixtures/test.md' },
                            { 'path' => 'spec/fixtures/another.md' }] }]
         }

--- a/spec/ggm/env_spec.rb
+++ b/spec/ggm/env_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+describe GGM::Env do
+  let(:truthy_values) { %w[t true yes y 1].freeze }
+  let(:falsey_values) { %w[f false n no 0].freeze }
+
+  it 'returns nil for nil environment variables' do
+    expect(described_class['NOT_A_VAR']).to eq(nil)
+  end
+
+  %w[t true yes y 1].each do |val|
+    it "returns true for variables set to #{val}" do
+      ENV['TRUTHY_VAR'] = val.to_s
+      expect(described_class['TRUTHY_VAR']).to eq(true)
+    end
+  end
+
+  %w[f false n no 0].each do |val|
+    it "returns false for variables set to #{val}" do
+      ENV['FALSEY_VAR'] = val.to_s
+      expect(described_class['FALSEY_VAR']).to eq(false)
+    end
+  end
+
+  it 'returns a string for other values' do
+    ENV['OTHER_VAR'] = 'My string'
+    expect(described_class['OTHER_VAR']).to eq('My string')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,10 +16,18 @@ module GitlabMocks
   let(:mock_gitlab_error_response) { instance_double('gitlab_error_response') }
   let(:mock_gitlab_request) { instance_double('gitlab_request') }
   let(:mock_groups_response) { instance_double('groups_response') }
+  let(:mock_group_subgroups_response) { instance_double('group_subgroup_response') }
   let(:mock_group_projects_response) { instance_double('group_projects_response') }
 
   let(:mock_groups) do
     [Gitlab::ObjectifiedHash.new({ id: '12345', name: 'Test Group' })]
+  end
+
+  let(:mock_subgroups) do
+    [
+      Gitlab::ObjectifiedHash.new({ id: '123', name: 'Test SubGroup 1' }),
+      Gitlab::ObjectifiedHash.new({ id: '456', name: 'Test SubGroup 2' })
+    ]
   end
 
   let(:mock_group_projects) do
@@ -37,6 +45,11 @@ module GitlabMocks
   def with_gitlab_groups_response_success
     allow(mock_gitlab_client).to receive(:groups).and_return(mock_groups_response)
     allow(mock_groups_response).to receive(:auto_paginate).and_return(mock_groups)
+  end
+
+  def with_gitlab_group_subgroups_response_success
+    allow(mock_gitlab_client).to receive(:group_subgroups).and_return(mock_group_subgroups_response)
+    allow(mock_group_subgroups_response).to receive(:auto_paginate).and_return(mock_subgroups)
   end
 
   def with_gitlab_group_projects_response_success


### PR DESCRIPTION
In this PR we replace the `include_subgroups` boolean config option with the `excluded_subgroups` option.

`excluded_suubgroups` takes a list of regex strings. Any subgroup name which matches will be excluded from the ProjectSet that ggm will act upon.

We also allow for `.ggm.yaml` / `.ggm/.yml` in the default locations.

This closes #7 and #10 